### PR TITLE
sửa luồng hủy đơn đã thanh toán và bổ sung theo dõi giữ hàng

### DIFF
--- a/QuanApi/Controllers/BanHangTaiQuayController.cs
+++ b/QuanApi/Controllers/BanHangTaiQuayController.cs
@@ -571,10 +571,17 @@ namespace QuanApi.Controllers
 
             string trangThaiHoaDon;
             var cashPaymentMethods = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-             {
-    "cash", "Tiền mặt", "tiền mặt"
-    };
-            if (dto.Shipping && !string.IsNullOrWhiteSpace(dto.Address) && cashPaymentMethods.Contains(dto.PaymentMethod))
+            {
+                "cash", "Tiền mặt", "tiền mặt"
+            };
+            var transferPaymentMethods = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "bank", "transfer", "chuyenkhoan", "chuyen khoan", "chuyển khoản", "qr", "vnpay"
+            };
+            var shouldConfirmShippingPaidOrder = dto.Shipping
+                && !string.IsNullOrWhiteSpace(dto.Address)
+                && (cashPaymentMethods.Contains(dto.PaymentMethod) || transferPaymentMethods.Contains(dto.PaymentMethod));
+            if (shouldConfirmShippingPaidOrder)
             {
                 trangThaiHoaDon = "Đã xác nhận";
             }
@@ -1679,7 +1686,14 @@ namespace QuanApi.Controllers
                 {
                     "cash", "Tiền mặt", "tiền mặt"
                 };
-            if (dto.Shipping && !string.IsNullOrWhiteSpace(dto.Address) && cashPaymentMethods.Contains(dto.PaymentMethod))
+            var transferPaymentMethods = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    "bank", "transfer", "chuyenkhoan", "chuyen khoan", "chuyển khoản", "qr", "vnpay"
+                };
+            var shouldConfirmShippingPaidOrder = dto.Shipping
+                && !string.IsNullOrWhiteSpace(dto.Address)
+                && (cashPaymentMethods.Contains(dto.PaymentMethod) || transferPaymentMethods.Contains(dto.PaymentMethod));
+            if (shouldConfirmShippingPaidOrder)
             {
                 trangThaiHoaDon = "Đã xác nhận";
             }

--- a/QuanApi/Controllers/HoaDonsController.cs
+++ b/QuanApi/Controllers/HoaDonsController.cs
@@ -200,9 +200,28 @@ namespace QuanApi.Controllers
 							h.TrangThaiThanhToan,
 							h.PhuongThucThanhToan?.MaPhuongThuc,
 							h.PhuongThucThanhToan?.TenPhuongThuc);
+						var isOnlinePaidTransferConfirmed = IsOnlinePaidTransferConfirmed(
+							h.TrangThai,
+							h.TrangThaiThanhToan,
+							h.PhuongThucThanhToan?.MaPhuongThuc,
+							h.PhuongThucThanhToan?.TenPhuongThuc,
+							h.DiaChiGiaoHang);
+						var isStoreShipPaidConfirmed = IsStoreShipPaidConfirmed(
+							h.BanTaiQuay,
+							h.TrangThai,
+							h.TrangThaiThanhToan,
+							h.DiaChiGiaoHang);
 						var displayStatus = canHighlight
 							? "Đã thanh toán chờ xác nhận"
 							: h.TrangThai;
+						var highlightForAdmin = canHighlight || isOnlinePaidTransferConfirmed || isStoreShipPaidConfirmed;
+						var highlightNote = canHighlight
+							? "Đơn đã thanh toán chuyển khoản, đang chờ quản lý xác nhận."
+							: isStoreShipPaidConfirmed
+								? FormatPaidPaymentNote(h.PhuongThucThanhToan?.TenPhuongThuc)
+							: isOnlinePaidTransferConfirmed
+								? "Đã trả tiền chuyển khoản."
+								: null;
 
 						return new
 						{
@@ -222,10 +241,8 @@ namespace QuanApi.Controllers
 							h.SoLuongSanPham,
 							h.TrangThaiThanhToan,
 							h.PhuongThucThanhToan,
-							CanHighlightChuyenKhoanChoXacNhan = canHighlight,
-							GhiChuChuyenKhoanChoXacNhan = canHighlight
-								? "Đơn đã thanh toán chuyển khoản, đang chờ quản lý xác nhận."
-								: null
+							CanHighlightChuyenKhoanChoXacNhan = highlightForAdmin,
+							GhiChuChuyenKhoanChoXacNhan = highlightNote
 						};
 					})
 					.ToList();
@@ -302,6 +319,7 @@ namespace QuanApi.Controllers
 							PhiVanChuyenGoc = h.PhiVanChuyenGoc,
 							SoTienGiamPhiVanChuyen = h.SoTienGiamPhiVanChuyen,
 							TrangThai = h.TrangThai,
+							TrangThaiThanhToan = h.TrangThaiThanhToan,
 							NgayTao = h.NgayTao,
 							TenNguoiNhan = h.TenNguoiNhan,
 							SoDienThoaiNguoiNhan = h.SoDienThoaiNguoiNhan,
@@ -347,12 +365,39 @@ namespace QuanApi.Controllers
 										GiaBan = ct.SanPhamChiTiet.GiaBan,
 										SoLuongTonHienTai = ct.SanPhamChiTiet.SoLuong - ct.SanPhamChiTiet.SoLuongDatCho,
 										SoLuongDatMua = ct.SoLuong,
-										SoLuongTonTruocXacNhan = h.DaTruTonKho
+										SoLuongTonTruocXacNhan = (
+												h.DaTruTonKho
+												|| h.TrangThai == "Đã xác nhận"
+												|| h.TrangThai == "Chờ lấy hàng"
+												|| h.TrangThai == "Đang giao"
+												|| h.TrangThai == "Đã giao"
+												|| h.TrangThai == "Đã lấy hàng"
+												|| h.TrangThai == "Chờ giao hàng"
+												|| h.TrangThai == "Đang giao hàng"
+												|| h.TrangThai == "Giao hàng thành công"
+											)
 											? (ct.SanPhamChiTiet.SoLuong - ct.SanPhamChiTiet.SoLuongDatCho) + ct.SoLuong
 											: (ct.SanPhamChiTiet.SoLuong - ct.SanPhamChiTiet.SoLuongDatCho),
-										SoLuongTonDuKienSauHuy = (h.TrangThai == "Đã hủy" || h.TrangThai == "Đã hoàn tiền")
+										SoLuongTonDuKienSauHuy = (h.TrangThai == "Đã hủy")
 											? (ct.SanPhamChiTiet.SoLuong - ct.SanPhamChiTiet.SoLuongDatCho)
-											: (ct.SanPhamChiTiet.SoLuong - ct.SanPhamChiTiet.SoLuongDatCho) + ct.SoLuong,
+											: (
+												h.DaDatChoTonKho
+												|| h.DaTruTonKho
+												|| h.TrangThai == "Chờ xác nhận"
+												|| h.TrangThai == "DaThanhToan"
+												|| h.TrangThai == "Đã thanh toán"
+												|| h.TrangThai == "Đã thanh toán chờ xác nhận"
+												|| h.TrangThai == "Đã xác nhận"
+												|| h.TrangThai == "Chờ lấy hàng"
+												|| h.TrangThai == "Đang giao"
+												|| h.TrangThai == "Đã giao"
+												|| h.TrangThai == "Đã lấy hàng"
+												|| h.TrangThai == "Chờ giao hàng"
+												|| h.TrangThai == "Đang giao hàng"
+												|| h.TrangThai == "Giao hàng thành công"
+											)
+											? (ct.SanPhamChiTiet.SoLuong - ct.SanPhamChiTiet.SoLuongDatCho) + ct.SoLuong
+											: (ct.SanPhamChiTiet.SoLuong - ct.SanPhamChiTiet.SoLuongDatCho),
 										KichCo = ct.SanPhamChiTiet.KichCo != null ? new { TenKichCo = ct.SanPhamChiTiet.KichCo.TenKichCo } : null,
 										MauSac = ct.SanPhamChiTiet.MauSac != null ? new { TenMauSac = ct.SanPhamChiTiet.MauSac.TenMauSac } : null,
 										HoaTiet = ct.SanPhamChiTiet.HoaTiet != null ? new { TenHoaTiet = ct.SanPhamChiTiet.HoaTiet.TenHoaTiet } : null,
@@ -619,6 +664,11 @@ namespace QuanApi.Controllers
 		{
 			try
 			{
+				if (string.IsNullOrWhiteSpace(dto.TrangThai))
+				{
+					return BadRequest("Trạng thái cập nhật không hợp lệ.");
+				}
+
 				await using var tx = await _context.Database.BeginTransactionAsync();
 
 				var hoaDon = await _context.HoaDons
@@ -632,7 +682,49 @@ namespace QuanApi.Controllers
 				}
 
 				var oldStatus = hoaDon.TrangThai;
-				var lyDoHuy = dto.TrangThai == "Đã hủy"
+				var targetStatus = dto.TrangThai.Trim();
+				var isPaidOrder = OrderPaymentStatusRules.IsPaidOrder(oldStatus, hoaDon.TrangThaiThanhToan);
+
+				if (isPaidOrder &&
+					string.Equals(targetStatus, OrderPaymentStatusRules.CanceledStatus, StringComparison.OrdinalIgnoreCase) &&
+					!OrderPaymentStatusRules.IsRefunded(oldStatus))
+				{
+					return BadRequest("Đơn đã thanh toán phải hoàn tiền trước khi hủy. Vui lòng chuyển sang 'Chờ hoàn tiền' rồi xác nhận 'Đã hoàn tiền'.");
+				}
+
+				if (string.Equals(targetStatus, OrderPaymentStatusRules.PendingRefundStatus, StringComparison.OrdinalIgnoreCase))
+				{
+					if (!isPaidOrder)
+					{
+						return BadRequest("Chỉ đơn đã thanh toán mới được chuyển sang trạng thái 'Chờ hoàn tiền'.");
+					}
+
+					if (OrderPaymentStatusRules.IsCanceled(oldStatus) || OrderPaymentStatusRules.IsRefunded(oldStatus))
+					{
+						return BadRequest("Không thể yêu cầu hoàn tiền từ trạng thái hiện tại.");
+					}
+				}
+
+				if (string.Equals(targetStatus, OrderPaymentStatusRules.RefundedStatus, StringComparison.OrdinalIgnoreCase))
+				{
+					if (!isPaidOrder)
+					{
+						return BadRequest("Chỉ đơn đã thanh toán mới được xác nhận hoàn tiền.");
+					}
+
+					if (!OrderPaymentStatusRules.IsRefundRequested(oldStatus))
+					{
+						return BadRequest("Chỉ được xác nhận hoàn tiền cho đơn đang ở trạng thái 'Chờ hoàn tiền'.");
+					}
+				}
+
+				if (OrderPaymentStatusRules.IsRefunded(oldStatus) &&
+					!string.Equals(targetStatus, OrderPaymentStatusRules.CanceledStatus, StringComparison.OrdinalIgnoreCase))
+				{
+					return BadRequest("Đơn đã hoàn tiền chỉ có thể chuyển sang trạng thái 'Đã hủy'.");
+				}
+
+				var lyDoHuy = targetStatus == "Đã hủy"
 					? (dto.LyDoHuyDon ?? hoaDon.LyDoHuyDon)
 					: hoaDon.LyDoHuyDon;
 
@@ -640,7 +732,7 @@ namespace QuanApi.Controllers
 					.Select(x => new InventoryLine(x.IDSanPhamChiTiet, x.SoLuong))
 					.ToList();
 
-				if (dto.TrangThai == "Đã xác nhận" && oldStatus == "Chờ xác nhận")
+				if (targetStatus == "Đã xác nhận" && oldStatus == "Chờ xác nhận")
 				{
 					var commitResult = await _inventoryReservationService.CommitReservedAsync(inventoryLines, dto.NguoiCapNhat ?? "System");
 					if (!commitResult.Success)
@@ -652,7 +744,7 @@ namespace QuanApi.Controllers
 					hoaDon.DaDatChoTonKho = false;
 					hoaDon.DaTruTonKho = true;
 				}
-				else if (dto.TrangThai == "Đã hủy" && oldStatus != "Đã hủy")
+				else if (targetStatus == "Đã hủy" && oldStatus != "Đã hủy")
 				{
 					if (hoaDon.DaDatChoTonKho)
 					{
@@ -697,7 +789,7 @@ namespace QuanApi.Controllers
 
 				var affected = await _context.Database.ExecuteSqlInterpolatedAsync(
 					$@"UPDATE ""HoaDons""
-					   SET ""TrangThai"" = {dto.TrangThai},
+					   SET ""TrangThai"" = {targetStatus},
 					       ""NguoiCapNhat"" = {dto.NguoiCapNhat},
 					       ""LanCapNhatCuoi"" = {dto.LanCapNhatCuoi},
 					       ""LyDoHuyDon"" = {lyDoHuy},
@@ -712,22 +804,22 @@ namespace QuanApi.Controllers
 					return Conflict("Đơn hàng đã được cập nhật bởi thao tác khác, vui lòng tải lại.");
 				}
 
-				await _orderHistoryService.SaveOrderHistoryAsync(id, oldStatus, dto.TrangThai, dto.NguoiCapNhat, dto.LyDoHuyDon);
+				await _orderHistoryService.SaveOrderHistoryAsync(id, oldStatus, targetStatus, dto.NguoiCapNhat, dto.LyDoHuyDon);
 				await _context.SaveChangesAsync();
 				await tx.CommitAsync();
 
-				hoaDon.TrangThai = dto.TrangThai;
+				hoaDon.TrangThai = targetStatus;
 				hoaDon.LyDoHuyDon = lyDoHuy;
 
-				_logger.LogInformation($"Updated order {id} status to {dto.TrangThai}");
+				_logger.LogInformation($"Updated order {id} status to {targetStatus}");
 
-				if (dto.TrangThai == "Đã hủy")
+				if (targetStatus == "Đã hủy")
 				{
 					await _emailService.SendOrderCancellationEmailAsync(hoaDon, dto.LyDoHuyDon);
 				}
 				else
 				{
-					await _emailService.SendOrderStatusChangeEmailAsync(hoaDon, oldStatus, dto.TrangThai);
+					await _emailService.SendOrderStatusChangeEmailAsync(hoaDon, oldStatus, targetStatus);
 				}
 
 				return Ok(new { message = "Cập nhật trạng thái thành công" });
@@ -1008,6 +1100,7 @@ namespace QuanApi.Controllers
 						MaHoaDon = h.MaHoaDon,
 						TongTien = h.TongTien,
 						BanTaiQuay = h.BanTaiQuay,
+						TrangThaiThanhToan = h.TrangThaiThanhToan ?? "Chưa thanh toán",
 						TrangThai = IsPaidTransferPendingConfirmation(
 							h.TrangThai,
 							h.TrangThaiThanhToan,
@@ -1015,6 +1108,13 @@ namespace QuanApi.Controllers
 							h.PhuongThucThanhToanTen)
 							? "Đã thanh toán chờ xác nhận"
 							: h.TrangThai,
+						PhuongThucThanhToan = (h.PhuongThucThanhToanMa != null || h.PhuongThucThanhToanTen != null)
+							? new PhuongThucThanhToan
+							{
+								MaPhuongThuc = h.PhuongThucThanhToanMa ?? string.Empty,
+								TenPhuongThuc = h.PhuongThucThanhToanTen ?? string.Empty
+							}
+							: null,
 						DiaChiGiaoHang = h.DiaChiGiaoHang,
 						NgayTao = h.NgayTao
 					})
@@ -1113,6 +1213,7 @@ namespace QuanApi.Controllers
 						MaHoaDon = h.MaHoaDon,
 						TongTien = h.TongTien,
 						BanTaiQuay = h.BanTaiQuay,
+						TrangThaiThanhToan = h.TrangThaiThanhToan ?? "Chưa thanh toán",
 						TrangThai = IsPaidTransferPendingConfirmation(
 							h.TrangThai,
 							h.TrangThaiThanhToan,
@@ -1120,6 +1221,13 @@ namespace QuanApi.Controllers
 							h.PhuongThucThanhToanTen)
 							? "Đã thanh toán chờ xác nhận"
 							: h.TrangThai,
+						PhuongThucThanhToan = (h.PhuongThucThanhToanMa != null || h.PhuongThucThanhToanTen != null)
+							? new PhuongThucThanhToan
+							{
+								MaPhuongThuc = h.PhuongThucThanhToanMa ?? string.Empty,
+								TenPhuongThuc = h.PhuongThucThanhToanTen ?? string.Empty
+							}
+							: null,
 						DiaChiGiaoHang = h.DiaChiGiaoHang,
 						NgayTao = h.NgayTao
 					})
@@ -1174,19 +1282,54 @@ namespace QuanApi.Controllers
 				return false;
 			}
 
-			var isPaidByPaymentStatus =
-				string.Equals(paymentStatus, "Đã thanh toán", StringComparison.OrdinalIgnoreCase);
-			var isPaidByOrderStatus =
-				string.Equals(orderStatus, "DaThanhToan", StringComparison.OrdinalIgnoreCase) ||
-				string.Equals(orderStatus, "Đã thanh toán", StringComparison.OrdinalIgnoreCase) ||
-				string.Equals(orderStatus, "Đã thanh toán chờ xác nhận", StringComparison.OrdinalIgnoreCase);
-
-			if (!isPaidByPaymentStatus && !isPaidByOrderStatus)
+			if (!IsPaidStatus(orderStatus, paymentStatus))
 			{
 				return false;
 			}
 
 			return IsTransferPaymentMethod(paymentMethodCode, paymentMethodName);
+		}
+
+		private static bool IsOnlinePaidTransferConfirmed(
+			string? orderStatus,
+			string? paymentStatus,
+			string? paymentMethodCode,
+			string? paymentMethodName,
+			string? shippingAddress)
+		{
+			if (string.IsNullOrWhiteSpace(shippingAddress))
+			{
+				return false;
+			}
+
+			if (!string.Equals(orderStatus, "Đã xác nhận", StringComparison.OrdinalIgnoreCase))
+			{
+				return false;
+			}
+
+			if (!IsPaidStatus(orderStatus, paymentStatus))
+			{
+				return false;
+			}
+
+			return IsTransferPaymentMethod(paymentMethodCode, paymentMethodName);
+		}
+
+		private static bool IsStoreShipPaidConfirmed(
+			bool banTaiQuay,
+			string? orderStatus,
+			string? paymentStatus,
+			string? shippingAddress)
+		{
+			return banTaiQuay
+				&& !string.IsNullOrWhiteSpace(shippingAddress)
+				&& string.Equals(orderStatus, "Đã xác nhận", StringComparison.OrdinalIgnoreCase)
+				&& IsPaidStatus(orderStatus, paymentStatus);
+		}
+
+		private static bool IsPaidStatus(string? orderStatus, string? paymentStatus)
+		{
+			return OrderPaymentStatusRules.IsPaidOrder(orderStatus, paymentStatus);
 		}
 
 		private static bool IsTransferPaymentMethod(string? paymentMethodCode, string? paymentMethodName)
@@ -1199,6 +1342,15 @@ namespace QuanApi.Controllers
 				|| normalized.Contains("transfer")
 				|| normalized.Contains("vnpay")
 				|| normalized.Contains("qr");
+		}
+
+		private static string FormatPaidPaymentNote(string? paymentMethodName)
+		{
+			var method = string.IsNullOrWhiteSpace(paymentMethodName)
+				? "không xác định phương thức thanh toán"
+				: paymentMethodName.Trim();
+
+			return $"Đã trả tiền: {method}.";
 		}
 
 		private static string RemoveDiacritics(string value)
@@ -1232,6 +1384,30 @@ namespace QuanApi.Controllers
 					&& (h.TrangThaiThanhToan == "Đã thanh toán"
 						|| h.TrangThai == "DaThanhToan"
 						|| h.TrangThai == "Đã thanh toán")
+					&& h.PhuongThucThanhToan != null
+					&& (
+						(h.PhuongThucThanhToan.MaPhuongThuc != null && (
+							h.PhuongThucThanhToan.MaPhuongThuc.ToLower().Contains("bank")
+							|| h.PhuongThucThanhToan.MaPhuongThuc.ToLower().Contains("transfer")
+							|| h.PhuongThucThanhToan.MaPhuongThuc.ToLower().Contains("vnpay")
+							|| h.PhuongThucThanhToan.MaPhuongThuc.ToLower().Contains("qr")
+						))
+						|| (h.PhuongThucThanhToan.TenPhuongThuc != null && (
+							h.PhuongThucThanhToan.TenPhuongThuc.ToLower().Contains("chuyển khoản")
+							|| h.PhuongThucThanhToan.TenPhuongThuc.ToLower().Contains("chuyen khoan")
+							|| h.PhuongThucThanhToan.TenPhuongThuc.ToLower().Contains("bank")
+							|| h.PhuongThucThanhToan.TenPhuongThuc.ToLower().Contains("transfer")
+							|| h.PhuongThucThanhToan.TenPhuongThuc.ToLower().Contains("vnpay")
+							|| h.PhuongThucThanhToan.TenPhuongThuc.ToLower().Contains("qr")
+						))
+					))
+				.ThenByDescending(h =>
+					!string.IsNullOrEmpty(h.DiaChiGiaoHang)
+					&& h.TrangThai == "Đã xác nhận"
+					&& (h.TrangThaiThanhToan == "Đã thanh toán"
+						|| h.TrangThai == "DaThanhToan"
+						|| h.TrangThai == "Đã thanh toán"
+						|| h.TrangThai == "Đã thanh toán chờ xác nhận")
 					&& h.PhuongThucThanhToan != null
 					&& (
 						(h.PhuongThucThanhToan.MaPhuongThuc != null && (

--- a/QuanApi/Controllers/SanPhamChiTietsController.cs
+++ b/QuanApi/Controllers/SanPhamChiTietsController.cs
@@ -547,6 +547,85 @@ namespace QuanApi.Controllers
             }
         }
 
+        [HttpPost("reservation-details")]
+        public async Task<IActionResult> GetReservationDetails([FromBody] ReservationDetailsRequest request)
+        {
+            try
+            {
+                if (request?.VariantIds == null || request.VariantIds.Count == 0)
+                    return Ok(new List<VariantReservationDetailDto>());
+
+                var variantIds = request.VariantIds
+                    .Where(id => id != Guid.Empty)
+                    .Distinct()
+                    .ToList();
+
+                if (variantIds.Count == 0)
+                    return Ok(new List<VariantReservationDetailDto>());
+
+                var reservedStatuses = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    "Chờ xác nhận",
+                    "Đã thanh toán chờ xác nhận",
+                    "DaThanhToan",
+                    "Đã thanh toán",
+                    "Đã xác nhận",
+                    "Chờ lấy hàng",
+                    "Đang giao",
+                    "Đã giao",
+                    "Đã lấy hàng",
+                    "Chờ giao hàng",
+                    "Đang giao hàng",
+                    "Giao hàng thành công"
+                };
+
+                var rows = await _context.ChiTietHoaDons
+                    .AsNoTracking()
+                    .Include(ct => ct.HoaDon)
+                        .ThenInclude(h => h.KhachHang)
+                    .Where(ct => variantIds.Contains(ct.IDSanPhamChiTiet)
+                                 && ct.TrangThai
+                                 && ct.HoaDon != null
+                                 && ct.HoaDon.TrangThaiHoaDon
+                                 && ct.HoaDon.DaDatChoTonKho
+                                 && ct.HoaDon.TrangThai != "Đã hủy")
+                    .Select(ct => new
+                    {
+                        ct.IDSanPhamChiTiet,
+                        IdHoaDon = ct.HoaDon!.IDHoaDon,
+                        MaDonHang = ct.HoaDon!.MaHoaDon,
+                        KhachHangTen = ct.HoaDon.KhachHang != null ? ct.HoaDon.KhachHang.TenKhachHang : null,
+                        TenNguoiNhan = ct.HoaDon.TenNguoiNhan,
+                        SoLuongDangGiu = ct.SoLuong,
+                        TrangThaiDon = ct.HoaDon.TrangThai,
+                        NgayTaoDon = ct.HoaDon.NgayTao
+                    })
+                    .ToListAsync();
+
+                var result = rows
+                    .Where(x => !string.IsNullOrWhiteSpace(x.TrangThaiDon) && reservedStatuses.Contains(x.TrangThaiDon))
+                    .OrderByDescending(x => x.NgayTaoDon)
+                    .ThenBy(x => x.MaDonHang)
+                    .Select(x => new VariantReservationDetailDto
+                    {
+                        IdSanPhamChiTiet = x.IDSanPhamChiTiet,
+                        IdHoaDon = x.IdHoaDon,
+                        MaDonHang = x.MaDonHang ?? string.Empty,
+                        TenKhachHang = !string.IsNullOrWhiteSpace(x.KhachHangTen) ? x.KhachHangTen : x.TenNguoiNhan,
+                        SoLuongDangGiu = x.SoLuongDangGiu,
+                        TrangThaiDon = x.TrangThaiDon ?? string.Empty
+                    })
+                    .ToList();
+
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Lỗi khi lấy reservation details cho biến thể.");
+                return StatusCode(500, "Lỗi khi tải chi tiết số lượng đặt trước");
+            }
+        }
+
         // DELETE: api/sanphamchitiets/{id} — luôn xóa mềm (TrangThai = false), không xóa hẳn bản ghi.
         [HttpDelete("{id}")]
         public async Task<IActionResult> Delete(Guid id)
@@ -625,6 +704,21 @@ namespace QuanApi.Controllers
                 : maSpChiTiet.Trim();
 
             return $"SPCT|{variantCode}|{idSanPhamChiTiet:D}";
+        }
+
+        public class ReservationDetailsRequest
+        {
+            public List<Guid> VariantIds { get; set; } = new();
+        }
+
+        public class VariantReservationDetailDto
+        {
+            public Guid IdSanPhamChiTiet { get; set; }
+            public Guid IdHoaDon { get; set; }
+            public string MaDonHang { get; set; } = string.Empty;
+            public string? TenKhachHang { get; set; }
+            public int SoLuongDangGiu { get; set; }
+            public string TrangThaiDon { get; set; } = string.Empty;
         }
     }
 }

--- a/QuanApi/Data/OrderPaymentStatusRules.cs
+++ b/QuanApi/Data/OrderPaymentStatusRules.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace QuanApi.Data
+{
+    public static class OrderPaymentStatusRules
+    {
+        public const string PendingRefundStatus = "Chờ hoàn tiền";
+        public const string RefundedStatus = "Đã hoàn tiền";
+        public const string CanceledStatus = "Đã hủy";
+        public const string PaidStatusNoAccent = "DaThanhToan";
+        public const string PaidStatus = "Đã thanh toán";
+        public const string PaidPendingConfirmStatus = "Đã thanh toán chờ xác nhận";
+        public const string PaymentPaidStatus = "Đã thanh toán";
+
+        public static bool IsPaidOrder(string? orderStatus, string? paymentStatus)
+        {
+            var isPaidByPaymentStatus =
+                string.Equals(paymentStatus, PaymentPaidStatus, StringComparison.OrdinalIgnoreCase);
+            var isPaidByOrderStatus =
+                string.Equals(orderStatus, PaidStatusNoAccent, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(orderStatus, PaidStatus, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(orderStatus, PaidPendingConfirmStatus, StringComparison.OrdinalIgnoreCase);
+
+            return isPaidByPaymentStatus || isPaidByOrderStatus;
+        }
+
+        public static bool IsRefundRequested(string? status)
+        {
+            return string.Equals(status, PendingRefundStatus, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool IsRefunded(string? status)
+        {
+            return string.Equals(status, RefundedStatus, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool IsCanceled(string? status)
+        {
+            return string.Equals(status, CanceledStatus, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/QuanApi/Services/OrderHistoryService.cs
+++ b/QuanApi/Services/OrderHistoryService.cs
@@ -22,6 +22,8 @@ namespace QuanApi.Services
             ["Chờ giao hàng"] = new List<string> { "Đang giao", "Đã hủy" },
             ["Đang giao hàng"] = new List<string> { "Đã giao", "Đã hủy" },
             ["Giao hàng thành công"] = new List<string>(), // Không thể chuyển sang trạng thái khác
+            ["Chờ hoàn tiền"] = new List<string> { "Đã hoàn tiền" },
+            ["Đã hoàn tiền"] = new List<string> { "Đã hủy" },
             ["Đã hủy"] = new List<string>() // Không thể chuyển sang trạng thái khác
         };
 
@@ -36,6 +38,8 @@ namespace QuanApi.Services
             ["Chờ giao hàng"] = new List<string> { "Đã lấy hàng" },
             ["Đang giao hàng"] = new List<string> { "Chờ giao hàng" },
             ["Giao hàng thành công"] = new List<string> { "Đã giao" },
+            ["Chờ hoàn tiền"] = new List<string>(),
+            ["Đã hoàn tiền"] = new List<string> { "Chờ hoàn tiền" },
             ["Đã hủy"] = new List<string>() // Không cho phép rollback từ trạng thái đã hủy
         };
 

--- a/QuanView/Areas/Admin/Controllers/QuanLyDonHangController.cs
+++ b/QuanView/Areas/Admin/Controllers/QuanLyDonHangController.cs
@@ -95,6 +95,7 @@ namespace QuanView.Areas.Admin.Controllers
             public decimal TyLeQuyDoiDiem { get; set; }
             public decimal? PhiVanChuyen { get; set; }
             public string TrangThai { get; set; }
+            public string? TrangThaiThanhToan { get; set; }
             public DateTime NgayTao { get; set; }
             public string TenNguoiNhan { get; set; }
             public string SoDienThoaiNguoiNhan { get; set; }
@@ -300,18 +301,6 @@ namespace QuanView.Areas.Admin.Controllers
                                 }
                             }
 
-                            var isStoreShipPaidConfirmed = hoaDonData.BanTaiQuay
-                                && !string.IsNullOrWhiteSpace(hoaDonData.DiaChiGiaoHang)
-                                && string.Equals(hoaDonData.TrangThai, "Đã xác nhận", StringComparison.OrdinalIgnoreCase);
-                            if (isStoreShipPaidConfirmed)
-                            {
-                                highlightedOrderIds.Add(hoaDonData.IDHoaDon);
-                                if (!highlightNotes.ContainsKey(hoaDonData.IDHoaDon))
-                                {
-                                    highlightNotes[hoaDonData.IDHoaDon] = "Đơn đã trả tiền tại quầy.";
-                                }
-                            }
-
                             hoaDons.Add(hoaDon);
                         }
 
@@ -327,15 +316,14 @@ namespace QuanView.Areas.Admin.Controllers
                         ViewBag.TotalPendingCount = result.Statistics?.TotalPendingCount ?? 0;
                         ViewBag.HighlightedOrderIds = highlightedOrderIds;
                         ViewBag.HighlightNotes = highlightNotes;
-						// ✅ SORT LOCAL (nếu API không xử lý)
-						if (sapXep == "asc")
-						{
-							hoaDons = hoaDons.OrderBy(h => h.NgayTao).ToList();
-						}
-						else
-						{
-							hoaDons = hoaDons.OrderByDescending(h => h.NgayTao).ToList();
-						}
+                        // Giữ nguyên thứ tự ưu tiên từ API; chỉ đổi chiều thời gian khi người dùng chọn tăng dần.
+                        if (string.Equals(sapXep, "asc", StringComparison.OrdinalIgnoreCase))
+                        {
+                            hoaDons = hoaDons
+                                .OrderByDescending(h => highlightedOrderIds.Contains(h.IDHoaDon))
+                                .ThenBy(h => h.NgayTao)
+                                .ToList();
+                        }
 						return View(hoaDons);
                     }
                     catch (System.Text.Json.JsonException jsonEx)
@@ -382,6 +370,7 @@ namespace QuanView.Areas.Admin.Controllers
                             TyLeQuyDoiDiem = hoaDonData.TyLeQuyDoiDiem,
                             PhiVanChuyen = hoaDonData.PhiVanChuyen ?? 0,
                             TrangThai = hoaDonData.TrangThai,
+                            TrangThaiThanhToan = hoaDonData.TrangThaiThanhToan ?? "Chưa thanh toán",
                             NgayTao = hoaDonData.NgayTao,
                             TenNguoiNhan = hoaDonData.TenNguoiNhan,
                             SoDienThoaiNguoiNhan = hoaDonData.SoDienThoaiNguoiNhan,
@@ -629,31 +618,37 @@ namespace QuanView.Areas.Admin.Controllers
                     return RedirectToAction(nameof(Details), new { id });
                 }
 
-                if (hoaDon.BanTaiQuay)
-                {
-                    TempData["ErrorMessage"] = "Chỉ cho phép hủy đơn online ở màn hình này.";
-                    return RedirectToAction(nameof(Details), new { id });
-                }
-
                 if (hoaDon.TrangThai == "Đã hủy")
                 {
                     TempData["ErrorMessage"] = "Đơn hàng đã ở trạng thái hủy.";
                     return RedirectToAction(nameof(Details), new { id });
                 }
 
+                var isPaidOrder = IsPaidOrder(hoaDon);
+                var targetStatus = "Đã hủy";
+                var successMessage = "Đã hủy đơn hàng thành công.";
+                var cancelReason = "Hủy đơn bởi quản trị viên";
+
+                if (isPaidOrder && !string.Equals(hoaDon.TrangThai, OrderPaymentStatusRules.RefundedStatus, StringComparison.OrdinalIgnoreCase))
+                {
+                    targetStatus = OrderPaymentStatusRules.PendingRefundStatus;
+                    successMessage = "Đơn đã thanh toán đã được chuyển sang trạng thái 'Chờ hoàn tiền'.";
+                    cancelReason = "Yêu cầu hoàn tiền trước khi hủy đơn đã thanh toán";
+                }
+
                 var payload = new
                 {
-                    TrangThai = "Đã hủy",
+                    TrangThai = targetStatus,
                     NguoiCapNhat = User.Identity?.Name ?? "Admin",
                     LanCapNhatCuoi = DateTime.UtcNow,
-                    LyDoHuyDon = "Hủy đơn bởi quản trị viên"
+                    LyDoHuyDon = cancelReason
                 };
 
                 var updateResponse = await _httpClient.PutAsJsonAsync($"HoaDons/{id}/trangthai", payload);
 
                 if (updateResponse.IsSuccessStatusCode)
                 {
-                    TempData["SuccessMessage"] = "Đã hủy đơn hàng thành công.";
+                    TempData["SuccessMessage"] = successMessage;
                 }
                 else
                 {
@@ -689,28 +684,21 @@ namespace QuanView.Areas.Admin.Controllers
                     return RedirectToAction(nameof(Details), new { id });
                 }
 
-                if (hoaDon.BanTaiQuay)
-                {
-                    TempData["ErrorMessage"] = "Chỉ hỗ trợ hoàn tiền cho đơn online.";
-                    return RedirectToAction(nameof(Details), new { id });
-                }
-
                 if (hoaDon.TrangThai == "Đã hoàn tiền")
                 {
                     TempData["ErrorMessage"] = "Đơn hàng đã được hoàn tiền trước đó.";
                     return RedirectToAction(nameof(Details), new { id });
                 }
 
-                if (hoaDon.TrangThai != "Đã hủy")
+                if (!IsPaidOrder(hoaDon))
                 {
-                    TempData["ErrorMessage"] = "Chỉ hoàn tiền cho đơn hàng đã hủy.";
+                    TempData["ErrorMessage"] = "Chỉ hoàn tiền cho đơn hàng đã thanh toán.";
                     return RedirectToAction(nameof(Details), new { id });
                 }
 
-                var tenPhuongThucThanhToan = hoaDon.PhuongThucThanhToan?.TenPhuongThuc ?? string.Empty;
-                if (!tenPhuongThucThanhToan.Contains("chuyển khoản", StringComparison.OrdinalIgnoreCase))
+                if (!string.Equals(hoaDon.TrangThai, OrderPaymentStatusRules.PendingRefundStatus, StringComparison.OrdinalIgnoreCase))
                 {
-                    TempData["ErrorMessage"] = "Chỉ hỗ trợ hoàn tiền cho đơn thanh toán chuyển khoản.";
+                    TempData["ErrorMessage"] = "Đơn chưa ở trạng thái 'Chờ hoàn tiền'.";
                     return RedirectToAction(nameof(Details), new { id });
                 }
 
@@ -724,7 +712,7 @@ namespace QuanView.Areas.Admin.Controllers
                 var updateResponse = await _httpClient.PutAsJsonAsync($"HoaDons/{id}/trangthai", payload);
                 if (updateResponse.IsSuccessStatusCode)
                 {
-                    TempData["SuccessMessage"] = "Đã hoàn tiền cho đơn hàng thành công.";
+                    TempData["SuccessMessage"] = "Đã xác nhận hoàn tiền. Có thể hoàn tất hủy đơn hàng.";
                 }
                 else
                 {
@@ -738,6 +726,11 @@ namespace QuanView.Areas.Admin.Controllers
             }
 
             return RedirectToAction(nameof(Details), new { id });
+        }
+
+        private static bool IsPaidOrder(HoaDonDetailDto hoaDon)
+        {
+            return OrderPaymentStatusRules.IsPaidOrder(hoaDon.TrangThai, hoaDon.TrangThaiThanhToan);
         }
 
         // POST: Admin/QuanLyDonHang/Rollback/{id}

--- a/QuanView/Areas/Admin/Controllers/SanPhamController.cs
+++ b/QuanView/Areas/Admin/Controllers/SanPhamController.cs
@@ -144,6 +144,50 @@ namespace QuanView.Areas.Admin.Controllers
 				}
 			}
 
+			var allVariantIds = products
+				.SelectMany(sp => sp.ChiTietSanPhams ?? new List<QuanView.Areas.Admin.Models.SanPhamChiTietDto>())
+				.Select(ct => ct.IdSanPhamChiTiet)
+				.Where(id => id != Guid.Empty)
+				.Distinct()
+				.ToList();
+
+			if (allVariantIds.Any())
+			{
+				var reservationRes = await _http.PostAsJsonAsync(
+					"sanphamchitiets/reservation-details",
+					new ReservationDetailsRequest { VariantIds = allVariantIds });
+
+				if (reservationRes.IsSuccessStatusCode)
+				{
+					var reservationDetails = await reservationRes.Content
+						.ReadFromJsonAsync<List<DonGiuHangChiTietDto>>(new JsonSerializerOptions
+						{
+							PropertyNameCaseInsensitive = true
+						}) ?? new List<DonGiuHangChiTietDto>();
+
+					var reservationByVariant = reservationDetails
+						.GroupBy(x => x.IdSanPhamChiTiet)
+						.ToDictionary(g => g.Key, g => g.ToList());
+
+					foreach (var sp in products)
+					{
+						foreach (var ct in sp.ChiTietSanPhams ?? new List<QuanView.Areas.Admin.Models.SanPhamChiTietDto>())
+						{
+							if (reservationByVariant.TryGetValue(ct.IdSanPhamChiTiet, out var holds))
+							{
+								ct.DanhSachDonDangGiu = holds;
+								ct.SoLuongDatCho = holds.Sum(x => x.SoLuongDangGiu);
+							}
+							else
+							{
+								ct.DanhSachDonDangGiu = new List<DonGiuHangChiTietDto>();
+								ct.SoLuongDatCho = 0;
+							}
+						}
+					}
+				}
+			}
+
 			// Tạo ViewModel với phân trang và bộ lọc
 			var viewModel = new SanPhamFilterViewModel
 			{
@@ -1646,6 +1690,11 @@ coXepLy, coGian, trangThaiSp,
 			}
 
 			return Json(new { success = true, urlAnh });
+		}
+
+		private sealed class ReservationDetailsRequest
+		{
+			public List<Guid> VariantIds { get; set; } = new();
 		}
 	}
 }

--- a/QuanView/Areas/Admin/Models/SanPhamChiTietDto.cs
+++ b/QuanView/Areas/Admin/Models/SanPhamChiTietDto.cs
@@ -33,6 +33,19 @@ namespace QuanView.Areas.Admin.Models
         // Thêm danh sách ảnh
         public List<AnhSanPhamDto> DanhSachAnh { get; set; } = new List<AnhSanPhamDto>();
 
+        // Danh sách đơn hàng đang giữ số lượng đặt trước của biến thể này.
+        public List<DonGiuHangChiTietDto> DanhSachDonDangGiu { get; set; } = new List<DonGiuHangChiTietDto>();
+
 		public bool IsDeleted { get; set; } = false;
 	}
+
+    public class DonGiuHangChiTietDto
+    {
+        public Guid IdSanPhamChiTiet { get; set; }
+        public Guid IdHoaDon { get; set; }
+        public string MaDonHang { get; set; } = string.Empty;
+        public string? TenKhachHang { get; set; }
+        public int SoLuongDangGiu { get; set; }
+        public string TrangThaiDon { get; set; } = string.Empty;
+    }
 }

--- a/QuanView/Areas/Admin/Views/ClientBanHangTaiQuay/Index.cshtml
+++ b/QuanView/Areas/Admin/Views/ClientBanHangTaiQuay/Index.cshtml
@@ -790,6 +790,40 @@
     </div>
 </div>
 
+<!-- Modal nhập nhanh thông tin khách vãng lai khi dùng mã giảm giá -->
+<div class="modal fade" id="guestContactDiscountModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Thông tin khách vãng lai</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <p class="text-muted mb-3" id="guestContactDiscountMessage">
+                    Vui lòng nhập SĐT hoặc email trước khi dùng mã giảm giá.
+                </p>
+                <div class="mb-2">
+                    <label class="form-label">Tên khách hàng (không bắt buộc)</label>
+                    <input type="text" class="form-control" id="guestContactName" placeholder="Nhập họ và tên">
+                </div>
+                <div class="mb-2">
+                    <label class="form-label">Số điện thoại</label>
+                    <input type="text" class="form-control" id="guestContactPhone" placeholder="Nhập số điện thoại">
+                </div>
+                <div class="mb-0">
+                    <label class="form-label">Email</label>
+                    <input type="email" class="form-control" id="guestContactEmail" placeholder="Nhập email">
+                </div>
+                <small class="text-danger d-block mt-2">* Chỉ cần nhập SĐT hoặc email.</small>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-secondary" data-bs-dismiss="modal">Để sau</button>
+                <button class="btn btn-primary" type="button" onclick="saveGuestContactForDiscount()">Lưu thông tin</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- Modal nhập số lượng sản phẩm -->
 <div class="modal fade" id="quantityModal" tabindex="-1">
     <div class="modal-dialog">
@@ -914,6 +948,9 @@
     let isHandlingQrScan = false;
     let html5QrCodeInstance = null;
     let qrDecodeHandled = false;
+    let shouldOpenVoucherAfterGuestContact = false;
+    let shouldRetryPaymentAfterGuestContact = false;
+    let pendingVoucherSelection = null;
 
     function cloneCustomerForCart(customer) {
         if (!customer) return null;
@@ -1390,8 +1427,121 @@
 
     // Áp dụng mã giảm giá
     function applyDiscount() {
+        if (!ensureGuestContactBeforeApplyDiscount()) {
+            return;
+        }
         loadCustomerDiscountVouchers();
     }
+
+    function isGuestCustomerForDiscountFlow() {
+        return !selectedCustomer || !!selectedCustomer.isGuest;
+    }
+
+    function getGuestContactInfo() {
+        return {
+            phone: ($('#shipPhone').val() || '').trim(),
+            email: ($('#shipEmail').val() || '').trim()
+        };
+    }
+
+    function hasGuestContactInfo() {
+        const contact = getGuestContactInfo();
+        return !!(contact.phone || contact.email);
+    }
+
+    function focusGuestContactModalInput() {
+        const phone = ($('#guestContactPhone').val() || '').trim();
+        const email = ($('#guestContactEmail').val() || '').trim();
+        if (!phone) {
+            $('#guestContactPhone').trigger('focus');
+            return;
+        }
+        if (!email) {
+            $('#guestContactEmail').trigger('focus');
+        }
+    }
+
+    function requestGuestContactForDiscount(message, options = {}) {
+        shouldOpenVoucherAfterGuestContact = !!options.afterOpenVoucher;
+        shouldRetryPaymentAfterGuestContact = !!options.afterPayInvoice;
+        pendingVoucherSelection = options.voucherSelection || null;
+
+        $('#guestContactDiscountMessage').text(message || 'Vui lòng nhập số điện thoại hoặc email cho khách vãng lai.');
+        $('#guestContactName').val(($('#shipName').val() || '').trim());
+        $('#guestContactPhone').val(($('#shipPhone').val() || '').trim());
+        $('#guestContactEmail').val(($('#shipEmail').val() || '').trim());
+        $('#guestContactDiscountModal').modal('show');
+        setTimeout(focusGuestContactModalInput, 150);
+    }
+
+    function saveGuestContactForDiscount() {
+        const name = ($('#guestContactName').val() || '').trim();
+        const phone = ($('#guestContactPhone').val() || '').trim();
+        const email = ($('#guestContactEmail').val() || '').trim();
+
+        if (!phone && !email) {
+            showWarning('Vui lòng nhập SĐT hoặc email.');
+            focusGuestContactModalInput();
+            return;
+        }
+
+        $('#shipName').val(name);
+        $('#shipPhone').val(phone);
+        $('#shipEmail').val(email);
+        $('#guestContactDiscountModal').modal('hide');
+        showSuccess('Đã lưu thông tin khách vãng lai.');
+
+        if (pendingVoucherSelection) {
+            const voucher = pendingVoucherSelection;
+            pendingVoucherSelection = null;
+            shouldOpenVoucherAfterGuestContact = false;
+            shouldRetryPaymentAfterGuestContact = false;
+            selectVoucher(voucher.code, voucher.giaTriGiam, voucher.giaTriGiamToiDa, voucher.donToiThieu);
+            return;
+        }
+
+        if (shouldOpenVoucherAfterGuestContact) {
+            shouldOpenVoucherAfterGuestContact = false;
+            shouldRetryPaymentAfterGuestContact = false;
+            loadCustomerDiscountVouchers();
+            return;
+        }
+
+        if (shouldRetryPaymentAfterGuestContact) {
+            shouldRetryPaymentAfterGuestContact = false;
+            shouldOpenVoucherAfterGuestContact = false;
+            payInvoice();
+            return;
+        }
+
+        shouldOpenVoucherAfterGuestContact = false;
+        shouldRetryPaymentAfterGuestContact = false;
+    }
+
+    function ensureGuestContactBeforeApplyDiscount() {
+        if (!isGuestCustomerForDiscountFlow()) {
+            return true;
+        }
+        if (hasGuestContactInfo()) {
+            return true;
+        }
+        requestGuestContactForDiscount('Khách vãng lai cần nhập SĐT hoặc email trước khi dùng mã giảm giá.', { afterOpenVoucher: true });
+        return false;
+    }
+
+    function ensureGuestContactForAppliedDiscount() {
+        const discountCode = ($('#discountCode').val() || '').trim();
+        const hasDiscountApplied = !!discountCode || Number(discountValue || 0) > 0;
+        if (!hasDiscountApplied || !isGuestCustomerForDiscountFlow()) {
+            return true;
+        }
+        if (hasGuestContactInfo()) {
+            return true;
+        }
+        requestGuestContactForDiscount('Khách vãng lai đã dùng mã giảm giá cần nhập SĐT hoặc email.', { afterPayInvoice: true });
+        return false;
+    }
+
     function tinhTienGiam(v, tongTien) {
         let discount = 0;
 
@@ -1635,6 +1785,13 @@
 
     // Chọn phiếu giảm giá
     function selectVoucher(code, giaTriGiam, giaTriGiamToiDa, donToiThieu) {
+        if (isGuestCustomerForDiscountFlow() && !hasGuestContactInfo()) {
+            requestGuestContactForDiscount('Nhập SĐT hoặc email trước khi áp dụng mã giảm giá cho khách vãng lai.', {
+                voucherSelection: { code: code, giaTriGiam: giaTriGiam, giaTriGiamToiDa: giaTriGiamToiDa, donToiThieu: donToiThieu }
+            });
+            return;
+        }
+
         let gh = gioHangs[currentGioHang];
         if (!gh || !gh.products) {
             showWarning('Không có giỏ hàng nào được chọn!');
@@ -2829,6 +2986,7 @@
         let gh = gioHangs[currentGioHang];
         if (!gh || !gh.products || gh.products.length === 0) return showError('Không có sản phẩm trong giỏ hàng!');
         if (!validateShippingAddressForPayment()) return;
+        if (!ensureGuestContactForAppliedDiscount()) return;
 
         // API cần MÃ phương thức (MaPhuongThuc, vd: "cash", "bank") chứ không phải tên hiển thị
         let paymentMethodCode = ($('#paymentMethod').val() || selectedPaymentCode || 'cash').trim();

--- a/QuanView/Areas/Admin/Views/QuanLyDonHang/Details.cshtml
+++ b/QuanView/Areas/Admin/Views/QuanLyDonHang/Details.cshtml
@@ -1,4 +1,5 @@
 ﻿@model QuanApi.Data.HoaDon
+@using QuanApi.Data
 @using QuanView.Areas.Admin.Models
 @{
     ViewData["Title"] = "Chi tiết đơn hàng";
@@ -92,11 +93,16 @@
             break;
     }
 
-    var isBankTransferOrder = (Model.PhuongThucThanhToan?.TenPhuongThuc ?? string.Empty)
-        .Contains("chuyển khoản", StringComparison.OrdinalIgnoreCase);
-    var canShowRefundButton = !Model.BanTaiQuay && currentStatus == "Đã hủy" && isBankTransferOrder;
+    var paymentMethodName = Model.PhuongThucThanhToan?.TenPhuongThuc ?? "không xác định";
+    var isPaidOrder = OrderPaymentStatusRules.IsPaidOrder(Model.TrangThai, Model.TrangThaiThanhToan);
+    var canShowRefundButton = string.Equals(Model.TrangThai, OrderPaymentStatusRules.PendingRefundStatus, StringComparison.OrdinalIgnoreCase) && isPaidOrder;
+    var canFinalizeCancel = string.Equals(Model.TrangThai, OrderPaymentStatusRules.RefundedStatus, StringComparison.OrdinalIgnoreCase);
+    var isStoreShipPaidOrder = Model.BanTaiQuay && !string.IsNullOrWhiteSpace(Model.DiaChiGiaoHang) && isPaidOrder;
     // currentStatus đã normalize "Giao hàng thành công" → "Đã giao"
-    var orderCompleted = currentStatus == "Đã giao" || currentStatus == "Đã hoàn tiền";
+    var orderCompleted = currentStatus == "Đã giao" || currentStatus == "Đã hủy";
+    var canAdvanceStatus = !orderCompleted
+        && !string.Equals(Model.TrangThai, OrderPaymentStatusRules.PendingRefundStatus, StringComparison.OrdinalIgnoreCase)
+        && !string.Equals(Model.TrangThai, OrderPaymentStatusRules.RefundedStatus, StringComparison.OrdinalIgnoreCase);
     // Chỉ dùng giá trị đã lưu trên hóa đơn (không suy từ cấu hình / bảng khác)
     var soTienGiamTuDiem = Model.SoTienGiamTuDiem;
     // Tạm tính = tiền hàng gốc (tổng thành tiền dòng); Tổng cộng = TongTien sau mọi cộng/trừ (voucher, điểm, ship…)
@@ -439,6 +445,14 @@
                         <h5>Đơn hàng đã hoàn tiền</h5>
                     </div>
                 }
+                else if (Model.TrangThai == "Chờ hoàn tiền")
+                {
+                    <div class="alert alert-warning text-center">
+                        <i class="fas fa-wallet fa-2x mb-2"></i>
+                        <h5>Đơn hàng đang chờ hoàn tiền</h5>
+                        <p class="mb-0">Cần xác nhận hoàn tiền trước khi hủy đơn.</p>
+                    </div>
+                }
                 else
                 {
                     <div class="timeline">
@@ -564,12 +578,22 @@
                                     }
                                     var hasStockSnapshot = stockSnapshot != null;
                                     var soLuongTonHienTai = hasStockSnapshot ? stockSnapshot.SoLuongTonHienTai : (chiTiet.SanPhamChiTiet?.SoLuong ?? 0);
-                                    var daTruKho = currentStatus == "Đã xác nhận"
+                                    var isConfirmedStage = currentStatus == "Đã xác nhận"
                                         || currentStatus == "Chờ lấy hàng"
                                         || currentStatus == "Đang giao"
-                                        || currentStatus == "Đã giao";
-                                    var soLuongTonTruocXacNhan = hasStockSnapshot ? stockSnapshot.SoLuongTonTruocXacNhan : (daTruKho ? soLuongTonHienTai + chiTiet.SoLuong : soLuongTonHienTai);
-                                    var soLuongTonDuKienSauHuy = hasStockSnapshot ? stockSnapshot.SoLuongTonDuKienSauHuy : (daTruKho ? soLuongTonHienTai + chiTiet.SoLuong : soLuongTonHienTai);
+                                        || currentStatus == "Đã giao"
+                                        || currentStatus == "Đã lấy hàng"
+                                        || currentStatus == "Chờ giao hàng"
+                                        || currentStatus == "Đang giao hàng"
+                                        || currentStatus == "Giao hàng thành công";
+                                    var isPendingConfirmationStage = currentStatus == "Chờ xác nhận"
+                                        || currentStatus == "DaThanhToan"
+                                        || currentStatus == "Đã thanh toán"
+                                        || currentStatus == "Đã thanh toán chờ xác nhận";
+                                    var isCanceledStage = currentStatus == "Đã hủy";
+                                    var canReturnOnCancel = !isCanceledStage && (isConfirmedStage || isPendingConfirmationStage);
+                                    var soLuongTonTruocXacNhan = hasStockSnapshot ? stockSnapshot.SoLuongTonTruocXacNhan : (isConfirmedStage ? soLuongTonHienTai + chiTiet.SoLuong : soLuongTonHienTai);
+                                    var soLuongTonDuKienSauHuy = hasStockSnapshot ? stockSnapshot.SoLuongTonDuKienSauHuy : (canReturnOnCancel ? soLuongTonHienTai + chiTiet.SoLuong : soLuongTonHienTai);
 
                                     <tr>
                                         <td>
@@ -626,7 +650,13 @@
                                 <i class="fas fa-money-check-alt"></i> Đơn hàng đã hoàn tiền
                             </div>
                         }
-                        else if (!orderCompleted)
+                        else if (string.Equals(Model.TrangThai, OrderPaymentStatusRules.PendingRefundStatus, StringComparison.OrdinalIgnoreCase))
+                        {
+                            <div class="alert alert-warning text-center">
+                                <i class="fas fa-wallet"></i> Đơn hàng đang chờ xác nhận hoàn tiền
+                            </div>
+                        }
+                        else if (canAdvanceStatus)
                         {
                             <form method="post" action="@Url.Action(nextAction, new { id = Model.IDHoaDon })">
                                 <button type="submit" class="btn btn-primary btn-block">
@@ -656,8 +686,8 @@
                         @if (canShowRefundButton)
                         {
                             <form method="post" action="@Url.Action("HoanTien", new { id = Model.IDHoaDon })" class="mt-2">
-                                <button type="submit" class="btn btn-success btn-block" onclick="return confirm('Bạn có chắc chắn đã hoàn tiền cho đơn hàng này?')">
-                                    <i class="fas fa-money-check-alt"></i> Hoàn tiền
+                                <button type="submit" class="btn btn-success btn-block" onclick="return confirm('Xác nhận đã hoàn tiền cho đơn hàng này?')">
+                                    <i class="fas fa-money-check-alt"></i> Xác nhận hoàn tiền
                                 </button>
                             </form>
                         }
@@ -665,15 +695,27 @@
                         @if (orderCompleted)
                         {
                         }
-                        else if (!Model.BanTaiQuay && Model.TrangThai != "Đã hủy" && Model.TrangThai != "Đã hoàn tiền")
+                        else if (canFinalizeCancel)
                         {
-                            var cancelMessage = Model.TrangThai == "Chờ xác nhận"
-                                ? "Bạn có chắc chắn muốn hủy đơn online này? Trạng thái sẽ chuyển sang Đã hủy."
-                                : "Bạn có chắc chắn muốn hủy đơn online này? Trạng thái sẽ chuyển sang Đã hủy và số lượng sản phẩm sẽ được hoàn lại kho.";
+                            <form method="post" action="@Url.Action("HuyDonHang", new { id = Model.IDHoaDon })" class="mt-2">
+                                <button type="submit" class="btn btn-danger btn-block" onclick="return confirm('Đơn đã hoàn tiền. Bạn có chắc chắn muốn hoàn tất hủy đơn?')">
+                                    <i class="fas fa-times-circle"></i> Hoàn tất hủy đơn
+                                </button>
+                            </form>
+                        }
+                        else if (Model.TrangThai != "Đã hủy"
+                            && !string.Equals(Model.TrangThai, OrderPaymentStatusRules.PendingRefundStatus, StringComparison.OrdinalIgnoreCase))
+                        {
+                            var cancelMessage = isPaidOrder
+                                ? "Đơn đã thanh toán sẽ được chuyển sang Chờ hoàn tiền. Bạn có chắc chắn muốn tiếp tục?"
+                                : (Model.TrangThai == "Chờ xác nhận"
+                                    ? "Bạn có chắc chắn muốn hủy đơn này? Trạng thái sẽ chuyển sang Đã hủy."
+                                    : "Bạn có chắc chắn muốn hủy đơn này? Trạng thái sẽ chuyển sang Đã hủy và số lượng sản phẩm sẽ được hoàn lại kho.");
+                            var cancelButtonText = isPaidOrder ? "Yêu cầu hoàn tiền" : "Hủy đơn hàng";
 
                             <form method="post" action="@Url.Action("HuyDonHang", new { id = Model.IDHoaDon })" class="mt-2">
                                 <button type="submit" class="btn btn-danger btn-block" onclick="return confirm('@cancelMessage')">
-                                    <i class="fas fa-times-circle"></i> Hủy đơn hàng
+                                    <i class="fas fa-times-circle"></i> @cancelButtonText
                                 </button>
                             </form>
                         }
@@ -718,8 +760,14 @@
                     <hr>
                     <div class="info-row">
                         <span class="info-label">Phương thức thanh toán:</span>
-                        <span class="info-value">@(Model.PhuongThucThanhToan?.TenPhuongThuc ?? "N/A")</span>
+                        <span class="info-value">@paymentMethodName</span>
                     </div>
+                    @if (isStoreShipPaidOrder)
+                    {
+                        <div class="alert alert-warning py-2 px-3 mb-3">
+                            <strong>Note:</strong> Đã trả tiền: @paymentMethodName.
+                        </div>
+                    }
                     <div class="info-row">
                         <span class="info-label">Ngày tạo:</span>
                         <span class="info-value">@Model.NgayTao.AddHours(7).ToString("dd/MM/yyyy HH:mm")</span>

--- a/QuanView/Areas/Admin/Views/QuanLyDonHang/Index.cshtml
+++ b/QuanView/Areas/Admin/Views/QuanLyDonHang/Index.cshtml
@@ -259,6 +259,10 @@
                                         selected="@(qTrangThai == "DaThanhToan" ? "selected" : null)">
                                     Đã thanh toán
                                 </option>
+                                <option value="Chờ hoàn tiền"
+                                        selected="@(qTrangThai == "Chờ hoàn tiền" ? "selected" : null)">
+                                    Chờ hoàn tiền
+                                </option>
                                        @*  <option value="Giao hàng thành công"
                                                 selected="@(qTrangThai == "Giao hàng thành công" ? "selected" : null)">
                                             Giao hàng thành công</option> *@
@@ -427,6 +431,7 @@
                                                     <th>Khách hàng</th>
                                                     <th>Tổng tiền</th>
                                                     <th>Trạng thái</th>
+                                                    <th>Loại đơn hàng</th>
                                 @{
                                     var currentSort = Context.Request.Query["sapXep"].ToString();
                                     if (string.IsNullOrEmpty(currentSort))
@@ -488,6 +493,7 @@
                                                                     "Đã giao" => "status-delivered",
                                                 "DaThanhToan" => "status-completed",
                                                                     "Giao hàng thành công" => "status-success",
+                                                                    "Chờ hoàn tiền" => "status-transfer-pending",
                                                                     "Đã hủy" => "status-cancelled",
                                                                     "Đã hoàn tiền" => "status-completed",
                                                                     _ => "status-pending"
@@ -508,6 +514,23 @@
                                                                 <div>
                                                                     <small class="text-success font-weight-bold">@highlightNote</small>
                                                                 </div>
+                                                            }
+                                                        </td>
+                                                        <td>
+                                                            @if (hoaDon.BanTaiQuay)
+                                                            {
+                                                                if (!string.IsNullOrWhiteSpace(hoaDon.DiaChiGiaoHang))
+                                                                {
+                                                                    <span class="badge badge-warning">Tại quầy (ship về)</span>
+                                                                }
+                                                                else
+                                                                {
+                                                                    <span class="badge badge-secondary">Tại quầy</span>
+                                                                }
+                                                            }
+                                                            else
+                                                            {
+                                                                <span class="badge badge-primary">Online</span>
                                                             }
                                                         </td>
                                                         <td>

--- a/QuanView/Areas/Admin/Views/SanPham/Index.cshtml
+++ b/QuanView/Areas/Admin/Views/SanPham/Index.cshtml
@@ -56,7 +56,7 @@
             margin-bottom: 20px;
             border: 1px solid #dee2e6;
             border-radius: 8px;
-            overflow: hidden;
+            overflow: visible;
             box-shadow: 0 2px 4px rgba(0,0,0,0.05);
         }
 
@@ -225,6 +225,101 @@
         }
         .variant-section table td, .variant-section table th {
             vertical-align: middle !important;
+        }
+        .stock-availability {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            flex-wrap: wrap;
+            justify-content: center;
+            overflow: visible;
+        }
+        .reservation-count {
+            font-size: 0.78rem;
+            color: #a16207;
+            background: #fff3cd;
+            border: 1px solid #ffe69c;
+            border-radius: 10px;
+            padding: 1px 8px;
+            white-space: nowrap;
+        }
+        .reservation-info-wrapper {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            z-index: 2000;
+        }
+        .reservation-info-icon {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 18px;
+            height: 18px;
+            border-radius: 50%;
+            background: #0d6efd;
+            color: #fff;
+            font-size: 0.72rem;
+            font-weight: 700;
+            cursor: pointer;
+            user-select: none;
+        }
+        .reservation-popup {
+            position: absolute;
+            top: calc(100% + 4px);
+            left: 50%;
+            transform: translateX(-50%);
+            width: 320px;
+            max-height: 240px;
+            overflow-y: auto;
+            text-align: left;
+            background: #fff;
+            border: 1px solid #dee2e6;
+            border-radius: 8px;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+            padding: 8px;
+            z-index: 9999;
+            opacity: 0;
+            visibility: hidden;
+            pointer-events: none;
+            transition: opacity 0.12s ease;
+        }
+        /* Cầu hover giữa icon và popup để tránh bị mất trạng thái khi rê chuột */
+        .reservation-popup::before {
+            content: "";
+            position: absolute;
+            top: -12px;
+            left: 0;
+            right: 0;
+            height: 12px;
+        }
+        .reservation-info-wrapper:hover .reservation-popup {
+            opacity: 1;
+            visibility: visible;
+            pointer-events: auto;
+        }
+        .reservation-popup-title {
+            font-size: 0.78rem;
+            font-weight: 700;
+            color: #0d6efd;
+            margin-bottom: 6px;
+        }
+        .reservation-item {
+            border-top: 1px dashed #e9ecef;
+            padding: 6px 2px;
+            font-size: 0.74rem;
+            line-height: 1.35;
+        }
+        .reservation-order-link {
+            color: #0d6efd;
+            text-decoration: none;
+            font-weight: 600;
+        }
+        .reservation-order-link:hover {
+            text-decoration: underline;
+        }
+        .reservation-item:first-of-type {
+            border-top: none;
+            padding-top: 2px;
         }
 		.card-stats {
     cursor: pointer;
@@ -617,7 +712,42 @@ keyframes blink-warning {
                                             <strong class="text-secondary">@ct.SoLuongVatLy</strong>
                                         </td>
                                         <td class="text-center">
-                                            <strong class="text-primary">@ct.SoLuongKhaDung</strong>
+                                            <div class="stock-availability">
+                                                <strong class="text-primary">@ct.SoLuongKhaDung</strong>
+                                                <span class="reservation-count">Đặt trước: @ct.SoLuongDatCho</span>
+                                                @if (ct.SoLuongDatCho > 0 && ct.DanhSachDonDangGiu.Any())
+                                                {
+                                                    <span class="reservation-info-wrapper" onclick="event.stopPropagation();">
+                                                        <span class="reservation-info-icon">i</span>
+                                                        <div class="reservation-popup">
+                                                            <div class="reservation-popup-title">Đơn đang giữ hàng</div>
+                                                            @foreach (var don in ct.DanhSachDonDangGiu)
+                                                            {
+                                                                <div class="reservation-item">
+                                                                    <div>
+                                                                        <strong>Mã đơn:</strong>
+                                                                        @if (don.IdHoaDon != Guid.Empty)
+                                                                        {
+                                                                            <a class="reservation-order-link"
+                                                                               href="@Url.Action("Details", "QuanLyDonHang", new { area = "Admin", id = don.IdHoaDon })"
+                                                                               onclick="event.stopPropagation();">
+                                                                                @don.MaDonHang
+                                                                            </a>
+                                                                        }
+                                                                        else
+                                                                        {
+                                                                            <span>@don.MaDonHang</span>
+                                                                        }
+                                                                    </div>
+                                                                    <div><strong>Khách:</strong> @(string.IsNullOrWhiteSpace(don.TenKhachHang) ? "Khách lẻ" : don.TenKhachHang)</div>
+                                                                    <div><strong>Giữ:</strong> @don.SoLuongDangGiu</div>
+                                                                    <div><strong>Trạng thái:</strong> @don.TrangThaiDon</div>
+                                                                </div>
+                                                            }
+                                                        </div>
+                                                    </span>
+                                                }
+                                            </div>
                                         </td>
                                         <td>
                                             @if (ct.originalPrice > ct.price)
@@ -915,7 +1045,8 @@ keyframes blink-warning {
                     if (e.target.closest('a') || 
                         e.target.closest('button') || 
                         e.target.closest('.form-check-input') ||
-                        e.target.closest('.variant-count-badge')) {
+                        e.target.closest('.variant-count-badge') ||
+                        e.target.closest('.reservation-info-wrapper')) {
                         return;
                     }
 

--- a/QuanView/Controller/DonHangController.cs
+++ b/QuanView/Controller/DonHangController.cs
@@ -451,6 +451,29 @@ namespace QuanView.Controllers
         {
             try
             {
+                var detailResponse = await _httpClient.GetAsync($"HoaDons/{id}");
+                if (!detailResponse.IsSuccessStatusCode)
+                {
+                    return Json(new { success = false, message = "Không tìm thấy đơn hàng." });
+                }
+
+                var order = await detailResponse.Content.ReadFromJsonAsync<HoaDon>();
+                if (order == null)
+                {
+                    return Json(new { success = false, message = "Không tìm thấy đơn hàng." });
+                }
+
+                var isPaidOrder = OrderPaymentStatusRules.IsPaidOrder(order.TrangThai, order.TrangThaiThanhToan);
+                var isRefunded = OrderPaymentStatusRules.IsRefunded(order.TrangThai);
+                if (isPaidOrder && !isRefunded)
+                {
+                    return Json(new
+                    {
+                        success = false,
+                        message = "Đơn đã thanh toán cần được hoàn tiền trước khi hủy. Vui lòng liên hệ cửa hàng để xử lý hoàn tiền."
+                    });
+                }
+
                 var response = await _httpClient.PutAsync($"HoaDons/{id}/trangthai",
                     new StringContent(JsonSerializer.Serialize(new
                     {

--- a/QuanView/Views/DonHang/Index.cshtml
+++ b/QuanView/Views/DonHang/Index.cshtml
@@ -1,4 +1,5 @@
 @model dynamic
+@using QuanApi.Data
 @{
     var lang = Context.Request.Cookies["UserLanguage"] ?? "vi";
     ViewData["Title"] = ((lang == "vi") ? "ĐƠN MUA CỦA TÔI" : "MY ORDERS");
@@ -205,6 +206,8 @@
                             <option value="Đã xác nhận" selected="@(trangThai == "Đã xác nhận")">Đã xác nhận</option>
                             <option value="Đang giao hàng" selected="@(trangThai == "Đang giao hàng")">Đang giao hàng</option>
                             <option value="Đã giao" selected="@(trangThai == "Đã giao")">Đã giao</option>
+                            <option value="Chờ hoàn tiền" selected="@(trangThai == "Chờ hoàn tiền")">Chờ hoàn tiền</option>
+                            <option value="Đã hoàn tiền" selected="@(trangThai == "Đã hoàn tiền")">Đã hoàn tiền</option>
                             <option value="Đã hủy" selected="@(trangThai == "Đã hủy")">Đã hủy</option>
                         </select>
                     </div>
@@ -303,13 +306,14 @@
                                 "Đã thanh toán chờ xác nhận" => "status-transfer-pending",
                                 "Đang giao hàng" => "status-shipping",
                                 "Giao hàng thành công" => "status-success",
+                                "Chờ hoàn tiền" => "status-transfer-pending",
+                                "Đã hoàn tiền" => "status-success",
                                 "Đã hủy" => "status-cancel",
                                 _ => "bg-light text-dark"
                             };
-                            var isTransferPending = hoaDon.TrangThai == "Đã thanh toán chờ xác nhận";
-                            var isStoreShipPaidConfirmed = hoaDon.BanTaiQuay
-                                && !string.IsNullOrEmpty(hoaDon.DiaChiGiaoHang)
-                                && hoaDon.TrangThai == "Đã xác nhận";
+                            var isTransferPending = string.Equals(hoaDon.TrangThai, "Đã thanh toán chờ xác nhận", StringComparison.OrdinalIgnoreCase);
+                            var isOnlinePaidTransferConfirmed = IsOnlinePaidTransferConfirmed(hoaDon);
+                            var isStoreShipPaidConfirmed = IsStoreShipPaidConfirmed(hoaDon);
                             var rowClass = isTransferPending
                                 ? "highlight-transfer-pending"
                                 : (isStoreShipPaidConfirmed ? "highlight-store-ship-paid" : "");
@@ -328,14 +332,25 @@
                                     }
                                     else if (isStoreShipPaidConfirmed)
                                     {
-                                        <div><small class="text-warning-emphasis fw-bold">Đã trả tiền tại quầy.</small></div>
+                                        <div>
+                                            <small class="text-warning-emphasis fw-bold">
+                                                @FormatPaidPaymentNote(hoaDon.PhuongThucThanhToan)
+                                            </small>
+                                        </div>
                                     }
                                 </td>
                                 <td>
-                                    @if (!string.IsNullOrEmpty(hoaDon.DiaChiGiaoHang)) {
-                                        <span class="small text-primary"><i class="bi bi-globe me-1"></i>Online</span>
+                                    @if (hoaDon.BanTaiQuay) {
+                                        if (!string.IsNullOrWhiteSpace(hoaDon.DiaChiGiaoHang))
+                                        {
+                                            <span class="small text-warning"><i class="bi bi-truck me-1"></i>Tại quầy (ship về)</span>
+                                        }
+                                        else
+                                        {
+                                            <span class="small text-muted"><i class="bi bi-shop me-1"></i>Tại quầy</span>
+                                        }
                                     } else {
-                                        <span class="small text-muted"><i class="bi bi-shop me-1"></i>Store</span>
+                                        <span class="small text-primary"><i class="bi bi-globe me-1"></i>Online</span>
                                     }
                                 </td>
                                 <td class="small text-muted">@hoaDon.NgayTao.AddHours(7).ToString("dd/MM/yyyy HH:mm")</td>
@@ -673,6 +688,83 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
 @functions {
+    private bool IsOnlinePaidTransferConfirmed(QuanApi.Data.HoaDon hoaDon)
+    {
+        if (hoaDon == null)
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(hoaDon.DiaChiGiaoHang))
+        {
+            return false;
+        }
+
+        if (!string.Equals(hoaDon.TrangThai, "Đã xác nhận", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!IsPaidStatus(hoaDon.TrangThai, hoaDon.TrangThaiThanhToan))
+        {
+            return false;
+        }
+
+        return IsTransferPaymentMethod(hoaDon.PhuongThucThanhToan);
+    }
+
+    private bool IsStoreShipPaidConfirmed(QuanApi.Data.HoaDon hoaDon)
+    {
+        if (hoaDon == null)
+        {
+            return false;
+        }
+
+        if (!hoaDon.BanTaiQuay || string.IsNullOrWhiteSpace(hoaDon.DiaChiGiaoHang))
+        {
+            return false;
+        }
+
+        if (!string.Equals(hoaDon.TrangThai, "Đã xác nhận", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return IsPaidStatus(hoaDon.TrangThai, hoaDon.TrangThaiThanhToan);
+    }
+
+    private bool IsPaidStatus(string? orderStatus, string? paymentStatus)
+    {
+        return OrderPaymentStatusRules.IsPaidOrder(orderStatus, paymentStatus);
+    }
+
+    private bool IsTransferPaymentMethod(QuanApi.Data.PhuongThucThanhToan? paymentMethod)
+    {
+        var methodCode = paymentMethod?.MaPhuongThuc?.ToLowerInvariant() ?? string.Empty;
+        var methodName = paymentMethod?.TenPhuongThuc?.ToLowerInvariant() ?? string.Empty;
+
+        return methodCode.Contains("bank")
+            || methodCode.Contains("transfer")
+            || methodCode.Contains("vnpay")
+            || methodCode.Contains("qr")
+            || methodName.Contains("chuyển khoản")
+            || methodName.Contains("chuyen khoan")
+            || methodName.Contains("bank")
+            || methodName.Contains("transfer")
+            || methodName.Contains("vnpay")
+            || methodName.Contains("qr");
+    }
+
+    private string FormatPaidPaymentNote(QuanApi.Data.PhuongThucThanhToan? paymentMethod)
+    {
+        var methodName = paymentMethod?.TenPhuongThuc;
+        var method = string.IsNullOrWhiteSpace(methodName)
+            ? "không xác định phương thức thanh toán"
+            : methodName.Trim();
+
+        return $"Đã trả tiền: {method}.";
+    }
+
     public string GetTrangThaiText(string trangThai)
     {
         return trangThai switch
@@ -687,6 +779,8 @@
             "Đang giao hàng" => "Đang giao hàng",
             "Đã giao" => "Đã giao",
             "Giao hàng thành công" => "Hoàn thành",
+            "Chờ hoàn tiền" => "Chờ hoàn tiền",
+            "Đã hoàn tiền" => "Đã hoàn tiền",
             "Đã hủy" => "Đã hủy",
             _ => trangThai
         };


### PR DESCRIPTION
Logic chỉnh sửa chính
Chuẩn hóa rule thanh toán/hoàn tiền

Thêm helper dùng chung OrderPaymentStatusRules để xác định đơn đã thanh toán, đang chờ hoàn tiền, đã hoàn tiền, đã hủy.
Dùng lại rule này ở cả API và View để tránh check status rời rạc.
Siết luồng hủy đơn đã thanh toán (Backend)

QuanApi/Controllers/HoaDonsController.cs thêm validate khi update trạng thái:
Đơn đã thanh toán không cho hủy thẳng.
Bắt buộc đi theo flow: Chờ hoàn tiền -> Đã hoàn tiền -> Đã hủy.
Chặn chuyển trạng thái sai ngữ cảnh, thêm message lỗi rõ.
Cập nhật trả dữ liệu có TrangThaiThanhToan, PhuongThucThanhToan, và logic highlight đơn cần xử lý.
Cập nhật transition lịch sử đơn

QuanApi/Services/OrderHistoryService.cs thêm trạng thái mới:
Chờ hoàn tiền -> Đã hoàn tiền
Đã hoàn tiền -> Đã hủy
Đồng bộ rollback map cho các trạng thái này.
Admin quản lý đơn hàng

QuanView/Areas/Admin/Controllers/QuanLyDonHangController.cs:
Hủy đơn giờ tự động chuyển sang Chờ hoàn tiền nếu đơn đã thanh toán.
Action hoàn tiền chỉ cho chạy khi đang ở Chờ hoàn tiền.
Bỏ hạn chế “chỉ online” ở một số nhánh kiểm tra, dựa trên trạng thái thanh toán thực tế.
QuanView/Areas/Admin/Views/QuanLyDonHang/Details.cshtml + Index.cshtml:
Thêm hiển thị trạng thái Chờ hoàn tiền.
Nút thao tác mới: yêu cầu hoàn tiền / xác nhận hoàn tiền / hoàn tất hủy.
Hiển thị note “đã trả tiền” rõ hơn cho đơn tại quầy có ship.
Bổ sung cột loại đơn: online / tại quầy / tại quầy (ship về).
Hiển thị giữ hàng theo biến thể sản phẩm

QuanApi/Controllers/SanPhamChiTietsController.cs thêm API POST sanphamchitiets/reservation-details.
QuanView/Areas/Admin/Controllers/SanPhamController.cs gọi API này để map số lượng giữ.
QuanView/Areas/Admin/Models/SanPhamChiTietDto.cs thêm DTO danh sách đơn giữ.
QuanView/Areas/Admin/Views/SanPham/Index.cshtml thêm UI badge + popup chi tiết đơn đang giữ hàng.
Luồng bán tại quầy: bắt buộc thông tin khách vãng lai khi dùng voucher

QuanView/Areas/Admin/Views/ClientBanHangTaiQuay/Index.cshtml:
Thêm modal nhập nhanh SĐT/email cho guest.
Chặn apply voucher / thanh toán nếu guest chưa có contact theo rule.
Trang đơn hàng khách

QuanView/Controller/DonHangController.cs: chặn khách hủy đơn đã thanh toán khi chưa hoàn tiền.
QuanView/Views/DonHang/Index.cshtml: thêm filter/status cho Chờ hoàn tiền, Đã hoàn tiền, cập nhật highlight/note phù hợp.